### PR TITLE
fix up advertisement in StartAirPlayServer() in NetworkServices.cpp for Gotham

### DIFF
--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -518,8 +518,8 @@ bool CNetworkServices::StartAirPlayServer()
   std::vector<std::pair<std::string, std::string> > txt;
   CNetworkInterface* iface = g_application.getNetwork().GetFirstConnectedInterface();
   txt.push_back(make_pair("deviceid", iface != NULL ? iface->GetMacAddress() : "FF:FF:FF:FF:FF:F2"));
-  txt.push_back(make_pair("features", "0x77"));
-  txt.push_back(make_pair("model", "Xbmc,1"));
+  txt.push_back(make_pair("features", "0x1000009FF"));
+  txt.push_back(make_pair("model", "AppleTV3,1"));
   txt.push_back(make_pair("srcvers", AIRPLAY_SERVER_VERSION_STR));
   CZeroconf::GetInstance()->PublishService("servers.airplay", "_airplay._tcp", g_infoManager.GetLabel(SYSTEM_FRIENDLY_NAME), g_advancedSettings.m_airPlayPort, txt);
 #endif // HAS_ZEROCONF


### PR DESCRIPTION
in Frodo the StartAirPlayServer() method was in xbmc/Application.cpp

this is moved in Gotham to network/NetworkServices.cpp. 

this commit makes sure the Zeroconf advertisements are updated in all places.
