### PR TITLE
always use dvdplayer for dvd content

### DIFF
--- a/system/playercorefactory.xml
+++ b/system/playercorefactory.xml
@@ -26,9 +26,9 @@
     </rule>
 
     <!-- DVDs -->
-    <rule name="dvd" dvd="true" player="videodefaultdvdplayer" />
-    <rule name="dvdfile" dvdfile="true" player="videodefaultdvdplayer" />
-    <rule name="dvdimage" dvdimage="true" player="videodefaultdvdplayer" />
+    <rule name="dvd" dvd="true" player="DVDPlayer" />
+    <rule name="dvdfile" dvdfile="true" player="DVDPlayer" />
+    <rule name="dvdimage" dvdimage="true" player="DVDPlayer" />
 
     <!-- Only dvdplayer can handle these normally -->
     <rule name="sdp/asf" filetypes="sdp|asf" player="videodefaultplayer" />


### PR DESCRIPTION
MPEG2 DVD is low profile enough that this should be the default and work reliably. 
