### PR TITLE
Adds variable which was missing but used in AdvancedSettings.cpp

### DIFF
--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -345,6 +345,8 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     unsigned int m_cacheBufferMode;
     float m_cacheReadFactor;
 
+    unsigned int m_libAssCache;
+
     bool m_jsonOutputCompact;
     unsigned int m_jsonTcpPort;
 


### PR DESCRIPTION
## Description
m_libAssCache was missing from .h

## Motivation and Context
Fixed compilation

## How Has This Been Tested?
Compiling code

## Screenshots (if appropriate):

## Types of change
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

