### PR TITLE
Adds -DRPI=1 to the compiler flags so that ffmpeg can be compiled with RPI optimisations

### DIFF
--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -14,6 +14,10 @@ if(CROSSCOMPILING)
   message(STATUS "CROSS: ${ffmpeg_conf}")
 endif()
 
+if(CORE_SYSTEM_NAME STREQUAL rbpi)
+  string(CONCAT CMAKE_C_FLAGS ${CMAKE_C_FLAGS} " -DRPI=1")
+endif()
+
 if(CMAKE_C_FLAGS)
   list(APPEND ffmpeg_conf --extra-cflags=${CMAKE_C_FLAGS})
 endif()


### PR DESCRIPTION
This is not enabled by default if compiled with cmake.
