### PR TITLE
Fixes: Libreelec 8.2.0.1 Rpi3 3D iso not playing properly

### DIFF
--- a/tools/depends/target/ffmpeg/pfcd_hevc_optimisations.patch
+++ b/tools/depends/target/ffmpeg/pfcd_hevc_optimisations.patch
@@ -433,6 +433,18 @@ index bb28aea1e2..741aa0bdc4 100644
 +
 +$(SUBDIR)rpi_qpu.o: $(SUBDIR)rpi_hevc_transform8.h $(SUBDIR)rpi_hevc_transform10.h
 +$(SUBDIR)hevcdec.o $(SUBDIR)rpi_shader_template.o $(SUBDIR)rpi_qpu.o: $(SUBDIR)rpi_shader.h
+diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
+index 54efaad..02a89c3 100644
+--- a/libavcodec/allcodecs.c
++++ b/libavcodec/allcodecs.c
+@@ -667,6 +667,7 @@ void avcodec_register_all(void)
+     REGISTER_PARSER(H261,               h261);
+     REGISTER_PARSER(H263,               h263);
+     REGISTER_PARSER(H264,               h264);
++    REGISTER_PARSER(H264_MVC,           h264_mvc);
+     REGISTER_PARSER(HEVC,               hevc);
+     REGISTER_PARSER(MJPEG,              mjpeg);
+     REGISTER_PARSER(MLP,                mlp);
 diff --git a/libavcodec/arm/Makefile b/libavcodec/arm/Makefile
 index a4ceca7f46..f8229a80e2 100644
 --- a/libavcodec/arm/Makefile
@@ -6979,6 +6991,135 @@ index 1bf1c620d6..ccfa991f60 100644
      const uint8_t *bytestream_start;
      const uint8_t *bytestream;
      const uint8_t *bytestream_end;
+diff --git a/libavcodec/codec_desc.c b/libavcodec/codec_desc.c
+index 9d94b72..535ebf0 100644
+--- a/libavcodec/codec_desc.c
++++ b/libavcodec/codec_desc.c
+@@ -1563,6 +1563,13 @@ static const AVCodecDescriptor codec_descriptors[] = {
+         .long_name = NULL_IF_CONFIG_SMALL("YUY2 Lossless Codec"),
+         .props     = AV_CODEC_PROP_INTRA_ONLY | AV_CODEC_PROP_LOSSLESS,
+     },
++    {
++        .id        = AV_CODEC_ID_H264_MVC,
++        .type      = AVMEDIA_TYPE_VIDEO,
++        .name      = "h264_mvc",
++        .long_name = NULL_IF_CONFIG_SMALL("H264 MVC"),
++        .props     = AV_CODEC_PROP_LOSSY,
++    },
+ 
+     /* various PCM "codecs" */
+     {
+diff --git a/libavcodec/h264.h b/libavcodec/h264.h
+index efe3555..16358aa 100644
+--- a/libavcodec/h264.h
++++ b/libavcodec/h264.h
+@@ -126,7 +126,9 @@ enum {
+     NAL_END_STREAM      = 11,
+     NAL_FILLER_DATA     = 12,
+     NAL_SPS_EXT         = 13,
++    NAL_SPS_SUBSET      = 15,
+     NAL_AUXILIARY_SLICE = 19,
++    NAL_SLICE_EXT       = 20,
+     NAL_FF_IGNORE       = 0xff0f001,
+ };
+ 
+diff --git a/libavcodec/h264_parser.c b/libavcodec/h264_parser.c
+index ce4bab2..b9b0c78 100644
+--- a/libavcodec/h264_parser.c
++++ b/libavcodec/h264_parser.c
+@@ -58,6 +58,8 @@ typedef struct H264ParseContext {
+     uint8_t parse_history[6];
+     int parse_history_count;
+     int parse_last_mb;
++    int is_mvc;
++    int slice_ext;
+ } H264ParseContext;
+ 
+ 
+@@ -105,24 +107,27 @@ static int h264_find_frame_end(H264ParseContext *p, const uint8_t *buf,
+         } else if (state <= 5) {
+             int nalu_type = buf[i] & 0x1F;
+             if (nalu_type == NAL_SEI || nalu_type == NAL_SPS ||
+-                nalu_type == NAL_PPS || nalu_type == NAL_AUD) {
++                nalu_type == NAL_PPS || nalu_type == NAL_AUD ||
++                nalu_type == NAL_SPS_SUBSET) {
+                 if (pc->frame_start_found) {
+                     i++;
+                     goto found;
+                 }
+             } else if (nalu_type == NAL_SLICE || nalu_type == NAL_DPA ||
+-                       nalu_type == NAL_IDR_SLICE) {
++                       nalu_type == NAL_IDR_SLICE || (p->is_mvc && nalu_type == NAL_SLICE_EXT)) {
+                 state += 8;
++
++                p->slice_ext = (nalu_type == NAL_SLICE_EXT);
+                 continue;
+             }
+             state = 7;
+         } else {
+             p->parse_history[p->parse_history_count++] = buf[i];
+-            if (p->parse_history_count > 5) {
++            if (p->parse_history_count > 8) {
+                 unsigned int mb, last_mb = p->parse_last_mb;
+                 GetBitContext gb;
+ 
+-                init_get_bits(&gb, p->parse_history, 8*p->parse_history_count);
++                init_get_bits8(&gb, p->parse_history + 3*p->slice_ext, p->parse_history_count - 3*p->slice_ext);
+                 p->parse_history_count = 0;
+                 mb= get_ue_golomb_long(&gb);
+                 p->parse_last_mb = mb;
+@@ -145,7 +150,7 @@ found:
+     pc->frame_start_found = 0;
+     if (p->is_avc)
+         return next_avc;
+-    return i - (state & 5) - 5 * (state > 7);
++    return i - (state & 5) - 8 * (state > 7);
+ }
+ 
+ static int scan_mmco_reset(AVCodecParserContext *s, GetBitContext *gb,
+@@ -585,7 +590,8 @@ static int h264_parse(AVCodecParserContext *s,
+         }
+     }
+ 
+-    parse_nal_units(s, avctx, buf, buf_size);
++    if (!p->is_mvc)
++        parse_nal_units(s, avctx, buf, buf_size);
+ 
+     if (avctx->framerate.num)
+         avctx->time_base = av_inv_q(av_mul_q(avctx->framerate, (AVRational){avctx->ticks_per_frame, 1}));
+@@ -622,7 +628,7 @@ static int h264_split(AVCodecContext *avctx,
+         if ((state & 0xFFFFFF00) != 0x100)
+             break;
+         nalu_type = state & 0x1F;
+-        if (nalu_type == NAL_SPS) {
++        if (nalu_type == NAL_SPS || nalu_type == NAL_SPS_SUBSET) {
+             has_sps = 1;
+         } else if (nalu_type == NAL_PPS)
+             has_pps = 1;
+@@ -672,3 +678,23 @@ AVCodecParser ff_h264_parser = {
+     .parser_close   = h264_close,
+     .split          = h264_split,
+ };
++
++static av_cold int init_mvc(AVCodecParserContext *s)
++{
++    H264ParseContext *p = s->priv_data;
++    int ret = init(s);
++    if (ret < 0)
++        return ret;
++
++    p->is_mvc = 1;
++    return 0;
++}
++
++AVCodecParser ff_h264_mvc_parser = {
++    .codec_ids      = { AV_CODEC_ID_H264_MVC },
++    .priv_data_size = sizeof(H264ParseContext),
++    .parser_init    = init_mvc,
++    .parser_parse   = h264_parse,
++    .parser_close   = h264_close,
++    .split          = h264_split,
++};
 diff --git a/libavcodec/hevc.c b/libavcodec/hevc.c
 index c1fa67f67b..6f99021339 100644
 --- a/libavcodec/hevc.c


### PR DESCRIPTION
This amends commit 7380227 with omitted MVC parser code for pfcd_hevc_optimisations.patch

<!--- Provide a general summary of your change in the Title above -->

## Description
<!--- Describe your change in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes LibreELEC 8.2.0.1 Rpi3 3D iso not playing properly
<!--- If it fixes an open issue, please link to the issue here -->
https://forum.libreelec.tv/thread/10421-libreelec-8-2-0-1-rpi3-3d-iso-not-playing-properly/

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
Applied patch to LibreEELEC.tv 8.2. Tested on Raspberry Pi3. Played several 3D ISO testing expected 
3D playback.

Ported patch to xbmc.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
