### PR TITLE
build: fix fmt dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,7 @@ list(APPEND install_data ${ADDON_INSTALL_DATA})
 add_library(compileinfo OBJECT ${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp)
 set_target_properties(compileinfo PROPERTIES FOLDER "Build Utilities")
 target_compile_options(compileinfo PRIVATE "${SYSTEM_DEFINES} ${ARCH_DEFINES}")
+add_dependencies(compileinfo fmt)
 
 # RC File
 if(WIN32)


### PR DESCRIPTION
## Description
Pointed out by Fuzzard in [this](https://forum.kodi.tv/showthread.php?tid=356924&pid=2975419#pid2975419) thread, CompileInfo now has a requirement of FMT due
to the inclusion of StringUtils.h in xbmc/CompileInfo.cpp.in introduced in a2519274c3.

Add an explicit dependency to CompileInfo target to fix the fmt error
described in the referenced thread.

Build-tested on Arch ARM armv7h (RPi4)

## Motivation and Context
Needed to fix build error, see linked thread above.

## How Has This Been Tested?
Build tested on Arch ARM armv7h on RPi4 using official Arch build system.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
