### PR TITLE
CPUInfo: make sure m_cpuFeatures is initialized

### DIFF
--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -115,7 +115,7 @@ protected:
   std::size_t m_totalTime{0};
 
   int m_cpuCount;
-  unsigned int m_cpuFeatures;
+  unsigned int m_cpuFeatures{0};
 
   std::vector<CoreInfo> m_cores;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
m_cpuFeatures is OR'ed into in implementations, but seemingly none of them initialized this field before they OR into, so do it first in CCPUInfo class.

## Motivation and Context
Fixes crash when starting Kodi on Raspberry Pi 1 due to mis-detecting NEON support.

## How Has This Been Tested?
Built using `m` script. Run on Raspberry Pi 1. At the moment, only the core is tested; the add-ons are not tested.

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [Code guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
