### PR TITLE
ffmpeg: remove typo in patch line

### DIFF
--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -160,7 +160,7 @@ include(ExternalProject)
 externalproject_add(ffmpeg
                     SOURCE_DIR ${CMAKE_SOURCE_DIR}
                     ${sourceplugin_patch}
-                    PATCH_COMMAND patch -p1 -i <SOURCE_DIR>/0001-rpi-Add-hevc-acceleration.patch
+                    PATCH_COMMAND -p1 -i <SOURCE_DIR>/0001-rpi-Add-hevc-acceleration.patch
                     CONFIGURE_COMMAND ${pkgconf} ${pkgconf_path} <SOURCE_DIR>/configure
                       --prefix=${CMAKE_INSTALL_PREFIX}
                       --extra-version="kodi-${FFMPEG_VER}"


### PR DESCRIPTION
Remove the call to patch after PATCH_COMMAND to fix build